### PR TITLE
Add checkout-submodules action

### DIFF
--- a/checkout-submodules/README.md
+++ b/checkout-submodules/README.md
@@ -1,0 +1,20 @@
+# checkout-submodules
+
+Recursively checks out submodules. This is possible with the default checkout
+action, but fails if you're using deploy keys.
+
+This action will specifically checkout submodules with the provided key.
+
+## Usage
+
+```
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      ...
+      - uses: actions/checkout@v2
+      - uses: ably/actions/checkout-submodules@main
+        with:
+          private_ssh_key: ${{ secrets.PRIVATE_SSH_KEY }}
+```

--- a/checkout-submodules/action.yaml
+++ b/checkout-submodules/action.yaml
@@ -1,0 +1,17 @@
+name: Checkout Submodules
+description: Recursively checkout submodules using a deploy key
+inputs:
+  private_ssh_key:
+    description: The private SSH key with permissions to required private repositories
+    required: true
+  key_type:
+    description: Either ecdsa or rsa
+    default: ecdsa
+runs:
+  using: "composite"
+  steps:
+    - run: $GITHUB_ACTION_PATH/run.sh
+      shell: bash
+      env:
+        KEY_TYPE: ${{ inputs.key_type }}
+        PRIVATE_SSH_KEY: ${{ inputs.private_ssh_key }}

--- a/checkout-submodules/run.sh
+++ b/checkout-submodules/run.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -eo pipefail
+
+SSH_KEY_NAME="id_$(date +%s)"
+SSH_KEY_PATH="${HOME}/.ssh/${SSH_KEY_NAME}"
+GIT_SSH_COMMAND="ssh -i ${SSH_KEY_PATH} -o IdentitiesOnly=yes" 
+export GIT_SSH_COMMAND
+
+main() {
+  mkdir -p ~/.ssh
+  echo "Adding private key: ${SSH_KEY_PATH}"
+  test -f "${SSH_KEY_PATH}" || echo "${PRIVATE_SSH_KEY}" > "${SSH_KEY_PATH}"
+  chmod 0400 "${SSH_KEY_PATH}"
+
+  if ! test -f "${HOME}/.ssh/known_hosts" || ! grep -q github.com "${HOME}/.ssh/known_hosts"; then
+    echo "Adding github.com identity (${KEY_TYPE})"
+    ssh-keyscan -t "${KEY_TYPE}" github.com >> "${HOME}/.ssh/known_hosts"
+  fi
+
+  git submodule update --init --recursive
+  echo "Submodules checked out"
+}
+
+cleanup() {
+  test -f "${SSH_KEY_PATH}" && rm "${SSH_KEY_PATH}"
+}
+
+trap cleanup EXIT
+
+main


### PR DESCRIPTION
A small action to checkout submodules. As noted, this is possible using the default action, but we're using deploy keys, which fail if the first identity tried is incorrect. Instead, this specifies the key to use.

This also serves as a styleguide for adding small, reusable bits of code. 