### PR TITLE
Add Push Docker Manifest action

### DIFF
--- a/push-docker-manifest/README.md
+++ b/push-docker-manifest/README.md
@@ -1,0 +1,17 @@
+# push-docker-manifest
+
+
+
+## Usage
+
+```
+jobs:
+  push_manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ably/actions/push-docker-manifest@main
+        with:
+          images: my-image, my-other-image
+          registry: ${{ secrets.REGISTRY }}
+          tag: my-tag
+```

--- a/push-docker-manifest/action.yaml
+++ b/push-docker-manifest/action.yaml
@@ -1,0 +1,24 @@
+name: Push Docker Manifest
+description: Create and push a Docker manifest for multi-architecture images
+inputs:
+  images:
+    description: A comma-delimited list of images to create a manifest for
+    type: string
+    required: true
+  registry:
+    description: The registry to push the manifest to
+    type: string
+    required: true
+  tag:
+    description: Release tag to tag the manifest with (manifests are tagged with SHA by default)
+    type: string
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - run: $GITHUB_ACTION_PATH/run.sh
+      shell: bash
+      env:
+        IMAGES: ${{ inputs.images }}
+        REGISTRY: ${{ inputs.registry }}
+        TAG: ${{ inputs.tag }}

--- a/push-docker-manifest/run.sh
+++ b/push-docker-manifest/run.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -eo pipefail
+
+ARCH_ARR=("amd64" "arm64")
+
+create_manifest() {
+  image=$1
+  tag=$2
+  fail=0
+  manifest_args=""
+
+  for arch in "${ARCH_ARR[@]}"
+  do
+    arch_manifest="${REGISTRY}/${image}:${tag}-${arch}"
+    echo "Finding ${arch_manifest}"
+    docker manifest inspect "${arch_manifest}" > /dev/null || {
+      echo "${arch_manifest} not available for ${arch}"
+      return_code=1
+      fail=1
+    }
+    manifest_args="${manifest_args} --amend ${arch_manifest}"
+  done
+
+  if [[ "${fail}" -eq "0" ]]; then
+    manifest="${REGISTRY}/${image}:${tag}"
+    echo "Pushing Manifest ${manifest} with ${manifest_args}"
+    docker manifest create "${manifest}" ${manifest_args}
+    docker manifest push --purge ${manifest}
+  fi
+}
+
+main() {
+  export return_code=0
+
+  for image in ${IMAGES//,/ }; do
+    if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
+      create_manifest "${image}" "main"
+    fi
+
+    create_manifest "${image}" "${TAG}"
+    create_manifest "${image}" "${GITHUB_SHA}"
+  done
+
+  return ${return_code}
+}
+
+main "$@"
+exit $?


### PR DESCRIPTION
Adds action that will create a push a Docker manifest for one or many multi-architecture images.

Manifests are tagged with SHA by default. An additional tag can be provided via the `tag` input. 

If the branch is `main`, a manifest with main will also be created/pushed.