### PR TITLE
Add step summaries

### DIFF
--- a/push-docker-manifest/run.sh
+++ b/push-docker-manifest/run.sh
@@ -32,6 +32,8 @@ create_manifest() {
 main() {
   export return_code=0
 
+  echo "### New images available" >> "${GITHUB_STEP_SUMMARY}"
+
   for image in ${IMAGES//,/ }; do
     if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
       create_manifest "${image}" "main"
@@ -39,6 +41,8 @@ main() {
 
     create_manifest "${image}" "${TAG}"
     create_manifest "${image}" "${GITHUB_SHA}"
+
+    echo "${image}:${TAG}" >> "${GITHUB_STEP_SUMMARY}"
   done
 
   return ${return_code}

--- a/update-builds/run.rb
+++ b/update-builds/run.rb
@@ -52,6 +52,7 @@ class Builds
       )
 
       set_output("release-tag", tag)
+      append_step_summary("**#{tag}**")
 
       puts "Build published:"
       puts JSON.pretty_generate(object)
@@ -153,6 +154,10 @@ class Builds
 
   def set_output(name, value)
     puts "::set-output name=#{name}::#{value}"
+  end
+
+  def append_step_summary(message)
+    File.write(ENV["GITHUB_STEP_SUMMARY"], message, mode: "a+")
   end
 end
 


### PR DESCRIPTION
Thought I'd try this out: https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/

You can see an example [here](https://github.com/ably/infrastructure/actions/runs/2340136348).