### PR TITLE
Allow building only a single architecture

### DIFF
--- a/push-docker-manifest/action.yaml
+++ b/push-docker-manifest/action.yaml
@@ -13,6 +13,12 @@ inputs:
     description: Release tag to tag the manifest with (manifests are tagged with SHA by default)
     type: string
     required: true
+  amd-only:
+    description: A comma-delimited list of images that are AMD only architecture
+    type: string
+  arm-only:
+    description: A comma-delimited list of images that are ARM only architecture
+    type: string
 runs:
   using: "composite"
   steps:
@@ -22,3 +28,5 @@ runs:
         IMAGES: ${{ inputs.images }}
         REGISTRY: ${{ inputs.registry }}
         TAG: ${{ inputs.tag }}
+        AMD_ONLY: ${{ inputs.amd-only }}
+        ARM_ONLY: ${{ inputs.arm-only }}


### PR DESCRIPTION
There are times where we're using 3rd party containers where running on a specific architecture isn't important. This allows us to skip building specific images on that architecture.