### PR TITLE
Skip notifications with empty webhook

### DIFF
--- a/notify/run.sh
+++ b/notify/run.sh
@@ -2,6 +2,14 @@
 #
 # Notify
 #
+set -eo pipefail
+
+if [[ -z $SLACK_WEBHOOK ]]; then
+  echo "No Slack webhook provided! Skipping notification."
+  echo "::warning title=Notify::Missing Slack webhook value"
+  exit 0
+fi
+
 COMMIT_MESSAGE=$(echo "$COMMIT_MESSAGE" | head -n1 | sed 's/"/\\"/g')
 
 if [[ -n "$DEFINED_JOB_STATUS" ]]; then


### PR DESCRIPTION
When Dependabot raises PRs, it doesn't have access to our secrets, and this action causes a failure.

I like notifications, but don't care if it doesn't run. We will add a warning instead.
