### PR TITLE
New step output syntax

### DIFF
--- a/publish-deploy/run.rb
+++ b/publish-deploy/run.rb
@@ -106,7 +106,7 @@ class Deployments
   end
 
   def set_output(name, value)
-    puts "::set-output name=#{name}::#{value}"
+    File.write(ENV["GITHUB_OUTPUT"], "#{name}=#{value}", mode: "a+")
   end
 
   def append_step_summary(message)

--- a/update-builds/run.rb
+++ b/update-builds/run.rb
@@ -153,7 +153,7 @@ class Builds
   end
 
   def set_output(name, value)
-    puts "::set-output name=#{name}::#{value}"
+    File.write(ENV["GITHUB_OUTPUT"], "#{name}=#{value}", mode: "a+")
   end
 
   def append_step_summary(message)


### PR DESCRIPTION
The `set-output` command is deprecated[1], and replaced with a `${GITHUB_OUTPUT}` file[2].

[1] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
[2] https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
