### PR TITLE
Fix empty Slack webhook again

### DIFF
--- a/notify/run.sh
+++ b/notify/run.sh
@@ -2,6 +2,14 @@
 #
 # Notify
 #
+set -eo pipefail
+
+if [[ -z $SLACK_WEBHOOK ]]; then
+  echo "No Slack webhook provided! Skipping notification."
+  echo "::warning title=Notify::Missing Slack webhook value"
+  exit 0
+fi
+
 COMMIT_MESSAGE=$(echo "$COMMIT_MESSAGE" | head -n1 | sed 's/"/\\"/g')
 
 if [[ -n "$DEFINED_JOB_STATUS" ]]; then

--- a/notify/run.sh
+++ b/notify/run.sh
@@ -2,8 +2,6 @@
 #
 # Notify
 #
-set -eo pipefail
-
 if [[ -z $SLACK_WEBHOOK ]]; then
   echo "No Slack webhook provided! Skipping notification."
   echo "::warning title=Notify::Missing Slack webhook value"


### PR DESCRIPTION
This reverts the commit I did previously, but also removes the `set -eo pipefail` which was causing something else to fail. For our immediate purposes I think we can dispense with this, and just leave the clean empty webhook warning and exit.