### PR TITLE
Enumerate through deploy manifests

### DIFF
--- a/publish-deploy/run.rb
+++ b/publish-deploy/run.rb
@@ -85,7 +85,7 @@ class Deployments
       index_name: "id-index",
       key_condition_expression: "id = :id",
       expression_attribute_values: {":id" => manifest_id}
-    ).items.max_by { |i| [i["date"], i["iteration"]] }
+    ).flat_map(&:items).max_by { |i| [i.fetch("date").to_i, i.fetch("iteration").to_i] }
   end
 
   def generate_service_image_tags


### PR DESCRIPTION
DynamoDB returns an unordered list of manifests, but without enumerating through the API call then there's no guarantee we're actually returning all the manifests.

This wasn't an issue previously because we had too few, but now we've probably ticked over into needing to enumerate.

I've also ensured we're sorting by integer rather than strings.
