### PR TITLE
Retry push-docker-manifest

### DIFF
--- a/push-docker-manifest/run.sh
+++ b/push-docker-manifest/run.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -eo pipefail
 
+# How many times to retry the script
+RETRIES=3
+
 ARCH_ARR=("amd64" "arm64")
 
 create_manifest() {
@@ -81,5 +84,12 @@ main() {
   return ${return_code}
 }
 
-main "$@"
-exit $?
+COUNTER=0
+while [ "${COUNTER}" -lt "${RETRIES}" ]; do
+  if main "$@"; then exit 0; fi
+  COUNTER=$((COUNTER + 1))
+  echo "Failed to push manifest, retrying (${COUNTER}/${RETRIES})"
+done
+
+echo "Failed to push manifest, giving up"
+exit 1


### PR DESCRIPTION
This occasionally fails when the images aren't available yet, for whatever reason. It requires a human to push a button to retry. I personally hate being that human, so I'm fixing it with computers.
